### PR TITLE
カレンダーのプログラムを追加

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'optparse'
 require "date"
 

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -2,9 +2,9 @@ require 'optparse'
 require "date"
 
 # 日付を表示する部分の列数
-NumberOfColumnsForDaySection = 7
+NUMBER_OF_COLUMNS_FOR_DAY_SECTION = 7
 # 日付を表示する部分の行数
-NumberOfRowsForDaySection = 6
+NUMBER_OF_ROWS_FOR_DAY_SECTION = 6
 
 # コマンドライン引数を取得する
 options = ARGV.getopts('y:m:')
@@ -26,9 +26,9 @@ end
 # 日付の配列の先頭にスペースを挿入する
 day_section_texts = Array.new(first_day_of_month.wday, "  ") + day_section_texts
 # 日付の配列を日付を表示する部分の列数で区切る
-day_section_texts = day_section_texts.each_slice(NumberOfColumnsForDaySection).to_a
+day_section_texts = day_section_texts.each_slice(NUMBER_OF_COLUMNS_FOR_DAY_SECTION).to_a
 
 # カレンダーを表示する
 puts "      #{month}月 #{year}"
 puts "日 月 火 水 木 金 土"
-NumberOfRowsForDaySection.times { |i| puts day_section_texts[i]&.join(" ") || "\n" }
+NUMBER_OF_ROWS_FOR_DAY_SECTION.times { |i| puts day_section_texts[i]&.join(" ") || "\n" }

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,34 @@
+require 'optparse'
+require "date"
+
+# 日付を表示する部分の列数
+NumberOfColumnsForDaySection = 7
+# 日付を表示する部分の行数
+NumberOfRowsForDaySection = 6
+
+# コマンドライン引数を取得する
+options = ARGV.getopts('y:m:')
+
+today = Date.today
+year = options["y"]&.to_i || today.year
+month = options["m"]&.to_i || today.month
+first_day_of_month = Date.new(year, month, 1)
+last_day_of_month = Date.new(year, month, -1)
+
+# 表示する全ての日付を持った配列を作成して、配列内の日付を2文字分の幅の文字列に変換する
+day_section_texts = (1..last_day_of_month.day).to_a.map { |day| "%2d" % day }
+# 現在の日付を表示する場合はコマンドラインの文字色と背景色を反転させる
+if year == today.year && month == today.month
+  day_section_texts.each_with_index do |day_section_text, i|
+    day_section_texts[i] = "\e[7m#{day_section_texts[i]}\e[0m" if day_section_text == "%2d" % today.day
+  end
+end
+# 日付の配列の先頭にスペースを挿入する
+day_section_texts = Array.new(first_day_of_month.wday, "  ") + day_section_texts
+# 日付の配列を日付を表示する部分の列数で区切る
+day_section_texts = day_section_texts.each_slice(NumberOfColumnsForDaySection).to_a
+
+# カレンダーを表示する
+puts "      #{month}月 #{year}"
+puts "日 月 火 水 木 金 土"
+NumberOfRowsForDaySection.times { |i| puts day_section_texts[i]&.join(" ") || "\n" }


### PR DESCRIPTION
## 概要

[カレンダーのプログラム(Ruby)](https://bootcamp.fjord.jp/practices/194)のプラクティスの課題であるcalコマンドのように動作するプログラムを作成しました。
レビューをお願いいたします。

## 備考

[カレンダーのプログラム(Ruby)](https://bootcamp.fjord.jp/practices/194)のページに記載されている以下の必須要件と歓迎要件を達成しています。
(歓迎要件の「どのような引数が与えられようが、`cal`コマンドと同じ表示結果になる」の達成は見送りました。)

> 必須要件
> * `./cal.rb`で実行できること(`ruby cal.rb`としなくてよいこと)
>   * [rubyでコマンドを作る](https://bootcamp.fjord.jp/articles/40) を参考にしてください
> * `-m`で月を、`-y`で年を指定できる
>   * ただし、`-y`のみ指定して一年分のカレンダーを表示する機能の実装は不要
> * 引数を指定しない場合は、今月・今年のカレンダーが表示される
> * MacやWSLに入っているcalコマンドと同じ見た目になっている
>   * OSのcalコマンドと自分のcalコマンドの両方の実行結果を載せてください
> * 少なくとも1970年から2100年までは正しく表示される

> 歓迎要件
> * 今日の日付の部分の色が反転する(背景色と文字色が入れ替わる)
