### PR TITLE
オプションなしのlsコマンドを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+MAX_NUMBER_OF_COLUMNS = 3
+TAB_WIDTH = 8 # ターミナルのデフォルトのタブの文字数
+
+def main
+  file_names = Dir.glob('*')
+  number_of_rows = file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
+  column_width = calcurate_column_width(file_names)
+  output_file_names(file_names, number_of_rows, column_width)
+end
+
+def calcurate_column_width(file_names)
+  max_length_of_file_name = file_names.max_by(&:length).length
+  # FreeBSD版lsコマンドで列の幅を求める際に行われている下記のビット演算を参考に実装。
+  # colwidth = (colwidth + tabwidth) & ~(tabwidth - 1)
+  # 例: ファイル名の最大長が17、タブの文字数が8の場合、25(0001 1001)と7を論理反転した値(1111 1000)の論理積である24(0011 1000)が求まる。
+  (max_length_of_file_name + TAB_WIDTH) & ~(TAB_WIDTH - 1)
+end
+
+def output_file_names(file_names, number_of_rows, column_width)
+  number_of_rows.times do |row|
+    MAX_NUMBER_OF_COLUMNS.times do |column|
+      print file_names[row + number_of_rows * column]&.ljust(column_width)
+    end
+    puts
+  end
+end
+
+main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,10 +12,7 @@ end
 
 def calcurate_column_width(file_names)
   max_length_of_file_name = file_names.max_by(&:length).length
-  # FreeBSD版lsコマンドで列の幅を求める際に行われている下記のビット演算を参考に実装。
-  # colwidth = (colwidth + tabwidth) & ~(tabwidth - 1)
-  # 例: ファイル名の最大長が17、タブの文字数が8の場合、25(0001 1001)と7を論理反転した値(1111 1000)の論理積である24(0011 1000)が求まる。
-  (max_length_of_file_name + TAB_WIDTH) & ~(TAB_WIDTH - 1)
+  TAB_WIDTH * (max_length_of_file_name / TAB_WIDTH + 1)
 end
 
 def output_file_names(file_names, number_of_rows, column_width)


### PR DESCRIPTION
## 概要

* [プラクティス lsコマンドを作る1 \| FBC](https://bootcamp.fjord.jp/practices/221)の課題です。

* オプションなしのlsコマンドのふるまいをする`ls.rb`を作成しました。レビューをお願いいたします。

## 備考

* mainメソッドについて
  * [Rubyスクリプトにもmainメソッドを定義するといいかも、という話 \#Ruby \- Qiita](https://qiita.com/jnchito/items/4b4cae54170cc2f4377e)を参考に、mainメソッドを作成しました。

* 列の幅の求め方について
  * [lsのソースを読みました \- mfumiの日記](https://mfumi.hatenadiary.org/entry/20111012/1318347200)内に記載されていたFreeBSD版lsコマンドの下記のビット演算の実装を参考にしました。
  * > colwidth = (colwidth + tabwidth) & ~(tabwidth - 1)
  * ~~例: ファイル名の最大長が17、タブの文字数が8だった場合は、25(0001 1001)と7を論理反転した値(1111 1000)の論理積である24(0011 1000)が列の幅として求まります。~~
  * ~~(念のため)列の幅を求める式として妥当か確かめるために下記のコードを動かしてみました。~~
    * ~~結果を見て妥当そうだと判断し、実装に含めました。~~
  * (追記)上記の式と同じ結果となるような式を考え、下記の検算を行った上でコードに記載しました。
    * `TAB_WIDTH * (max_length_of_file_name / TAB_WIDTH + 1)`

```ruby
(1..30).each do |i|
  expected = (i + 8) & ~(8 - 1)
  actual = 8 * (i / 8 + 1)
  puts "FreeBSD版lsコマンドの式: #{expected}, 簡単にした式: #{actual}, 比較結果: #{expected == actual ? 'OK' : 'NG'}"
end
```

![スクリーンショット 2024-06-16 0 21 11](https://github.com/fukuroq/ruby-practices/assets/5906642/ba0cc42f-f1ef-4dc4-8e5d-b15f814a0223)
