### PR TITLE
lsコマンドに-aオプションを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,7 +7,7 @@ TAB_WIDTH = 8 # ターミナルのデフォルトのタブの文字数
 
 def main
   options = ARGV.getopts('a')
-  file_names = options['a'] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+  file_names = Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0)
   number_of_rows = file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
   column_width = calcurate_column_width(file_names)
   output_file_names(file_names, number_of_rows, column_width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require 'optparse'
+
 MAX_NUMBER_OF_COLUMNS = 3
 TAB_WIDTH = 8 # ターミナルのデフォルトのタブの文字数
 
 def main
-  file_names = Dir.glob('*')
+  options = ARGV.getopts('a')
+  file_names = options['a'] ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
   number_of_rows = file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
   column_width = calcurate_column_width(file_names)
   output_file_names(file_names, number_of_rows, column_width)


### PR DESCRIPTION
* [プラクティス lsコマンドを作る2 \| FBC](https://bootcamp.fjord.jp/practices/222)の課題です。
* `ls.rb`に、`-a`オプションのふるまいを追加しました。レビューをお願いいたします。