### PR TITLE
lsコマンドに-rオプションを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,11 +6,12 @@ MAX_NUMBER_OF_COLUMNS = 3
 TAB_WIDTH = 8 # ターミナルのデフォルトのタブの文字数
 
 def main
-  options = ARGV.getopts('a')
+  options = ARGV.getopts('ar')
   file_names = Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0)
-  number_of_rows = file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
-  column_width = calcurate_column_width(file_names)
-  output_file_names(file_names, number_of_rows, column_width)
+  sorted_file_names = options['r'] ? file_names.reverse : file_names
+  number_of_rows = sorted_file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
+  column_width = calcurate_column_width(sorted_file_names)
+  output_file_names(sorted_file_names, number_of_rows, column_width)
 end
 
 def calcurate_column_width(file_names)


### PR DESCRIPTION
## 概要

* [プラクティス lsコマンドを作る3 \| FBC](https://bootcamp.fjord.jp/practices/223)の課題です。
* `ls.rb`に、`-r`オプションのふるまいを追加しました。レビューをお願いいたします。
  * 下記のような記載がありましたが、`-a`オプションが実装された状態のコードに`-r`オプションの処理を追加する形にしました。
> 前回のプラクティスで実装した-aオプションは実装しなくてよいです。（このシリーズ最後のプラクティスで全部合体させます）

## 備考

* `sorted_file_names`という変数名について
  * 適切な変数名であるか、自信が持てていません
  * `-r`オプションをつけずに実行した場合は`reverse`メソッドが実行されないのに、「ソートされた」という扱いになってしまう点が個人的に気になっています
  * 一方、「`sorted_file_names`に代入された時点で、lsコマンドを実行したユーザーの意図通り(昇順 or 降順)に並んでいますよ」という意味で`sorted`と解釈すれば、違和感はないと思い、現状`sorted_file_names`にしています
    * 他に、より適切な変数名を思いつくことができなかったというのもあります