### PR TITLE
lsコマンドに-lオプションを追加

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -41,10 +41,10 @@ def main
   file_names = Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0)
   sorted_file_names = options['r'] ? file_names.reverse : file_names
   if options['l']
-    long_format_file_names = generate_long_format(sorted_file_names)
-    total_block_size = long_format_file_names.sum { |long_format_file_name| long_format_file_name[:block_size] }
-    long_format_widths = create_long_format_widths(long_format_file_names)
-    output_long_format(long_format_file_names, total_block_size, long_format_widths)
+    long_format_files = generate_long_format_files(sorted_file_names)
+    total_block_size = long_format_files.sum { |long_format_file| long_format_file[:block_size] }
+    long_format_widths = generate_long_format_widths(long_format_files)
+    output_long_format_files(long_format_files, total_block_size, long_format_widths)
   else
     number_of_rows = sorted_file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
     column_width = calcurate_column_width(sorted_file_names)
@@ -52,7 +52,7 @@ def main
   end
 end
 
-def generate_long_format(file_names)
+def generate_long_format_files(file_names)
   file_names.map do |file_name|
     file_status = File::Stat.new(file_name)
     {
@@ -94,27 +94,27 @@ def generate_timestamp(file_status)
   Time.now.year > modify_time.year ? modify_time.strftime('%_m %_d %_5Y') : modify_time.strftime('%_m %_d %H:%M')
 end
 
-def create_long_format_widths(long_format_file_names)
-  long_format_widths = {}
-  %i[hard_link owner_name group_name bytesize timestamp].each do |long_format_key|
-    long_format_widths[long_format_key] = long_format_file_names.map { |long_format_file_name| long_format_file_name[long_format_key].to_s.length }.max
+def generate_long_format_widths(files)
+  widths = {}
+  %i[hard_link owner_name group_name bytesize timestamp].each do |key|
+    widths[key] = files.map { |file| file[key].to_s.length }.max
   end
-  long_format_widths[:hard_link] += HARD_LINK_FORWARD_WIDTH
-  long_format_widths[:bytesize] += BYTESIZE_FORWARD_WIDTH
-  long_format_widths
+  widths[:hard_link] += HARD_LINK_FORWARD_WIDTH
+  widths[:bytesize] += BYTESIZE_FORWARD_WIDTH
+  widths
 end
 
-def output_long_format(long_format_file_names, total_block_size, long_format_widths)
+def output_long_format_files(files, total_block_size, widths)
   puts "total #{total_block_size}"
-  long_format_file_names.each do |long_format_file_name|
-    print long_format_file_name[:file_type]
-    print long_format_file_name[:permission]
-    print long_format_file_name[:hard_link].to_s.rjust(long_format_widths[:hard_link])
-    print long_format_file_name[:owner_name].ljust(long_format_widths[:owner_name]).center(long_format_widths[:owner_name] + LONG_FORMAT_SIDE_WIDTH)
-    print long_format_file_name[:group_name].ljust(long_format_widths[:group_name]).center(long_format_widths[:group_name] + LONG_FORMAT_SIDE_WIDTH)
-    print long_format_file_name[:bytesize].to_s.rjust(long_format_widths[:bytesize])
-    print long_format_file_name[:timestamp].to_s.center(long_format_widths[:timestamp] + LONG_FORMAT_SIDE_WIDTH)
-    print long_format_file_name[:file_name]
+  files.each do |file|
+    print file[:file_type]
+    print file[:permission]
+    print file[:hard_link].to_s.rjust(widths[:hard_link])
+    print file[:owner_name].ljust(widths[:owner_name]).center(widths[:owner_name] + LONG_FORMAT_SIDE_WIDTH)
+    print file[:group_name].ljust(widths[:group_name]).center(widths[:group_name] + LONG_FORMAT_SIDE_WIDTH)
+    print file[:bytesize].to_s.rjust(widths[:bytesize])
+    print file[:timestamp].to_s.center(widths[:timestamp] + LONG_FORMAT_SIDE_WIDTH)
+    print file[:file_name]
     puts
   end
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -71,10 +71,7 @@ end
 
 def generate_permission(file_status)
   file_mode = format('%06o', file_status.mode)
-  permission = ''
-  [OWNER_DIGIT, GROUP_DIGIT, OTHER_DIGIT].each do |digit|
-    permission += PERMISSIONS[file_mode[digit]]
-  end
+  permission = [OWNER_DIGIT, GROUP_DIGIT, OTHER_DIGIT].map { PERMISSIONS[file_mode[it]] }.join
   convert_permission(permission, file_status)
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,12 +6,33 @@ MAX_NUMBER_OF_COLUMNS = 3
 TAB_WIDTH = 8 # ターミナルのデフォルトのタブの文字数
 
 def main
-  options = ARGV.getopts('ar')
+  options = ARGV.getopts('arl')
   file_names = Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0)
   sorted_file_names = options['r'] ? file_names.reverse : file_names
-  number_of_rows = sorted_file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
-  column_width = calcurate_column_width(sorted_file_names)
-  output_file_names(sorted_file_names, number_of_rows, column_width)
+  if options['l']
+    long_format_file_names = generate_long_format(sorted_file_names)
+    total_block_size = long_format_file_names.inject(0) { |sum, hash| sum + hash[:block_size] }
+    output_long_format(long_format_file_names, total_block_size)
+  else
+    number_of_rows = sorted_file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
+    column_width = calcurate_column_width(sorted_file_names)
+    output_file_names(sorted_file_names, number_of_rows, column_width)
+  end
+end
+
+def generate_long_format(file_names)
+  long_format_file_names = []
+  file_names.each do |file_name|
+    file_status = File::Stat.new(file_name)
+    long_format_file_names << {
+      block_size: file_status.blocks
+    }
+  end
+  long_format_file_names
+end
+
+def output_long_format(long_format_file_names, total_block_size)
+  puts "total: #{total_block_size}"
 end
 
 def calcurate_column_width(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -4,6 +4,33 @@ require 'optparse'
 
 MAX_NUMBER_OF_COLUMNS = 3
 TAB_WIDTH = 8 # ターミナルのデフォルトのタブの文字数
+OWNER_DIGIT = 3
+GROUP_DIGIT = 4
+OTHER_DIGIT = 5
+SET_USER_ID_DIGIT = 2
+SET_GROUP_ID_DIGIT = 5
+STICKY_BIT_DIGIT = 8
+
+FILE_TYPES = {
+  'file' => '-',
+  'directory' => 'd',
+  'characterSpecial' => 'c',
+  'blockSpecial' => 'b',
+  'fifo' => 'p',
+  'link' => 'l',
+  'socket' => 's'
+}
+
+PERMISSIONS = {
+  '0' => '---',
+  '1' => '--x',
+  '2' => '-w-',
+  '3' => '-wx',
+  '4' => 'r--',
+  '5' => 'r-x',
+  '6' => 'rw-',
+  '7' => 'rwx'
+}
 
 def main
   options = ARGV.getopts('arl')
@@ -25,14 +52,43 @@ def generate_long_format(file_names)
   file_names.each do |file_name|
     file_status = File::Stat.new(file_name)
     long_format_file_names << {
-      block_size: file_status.blocks
+      block_size: file_status.blocks,
+      file_type: FILE_TYPES[file_status.ftype],
+      permission: generate_permission(file_status)
     }
   end
   long_format_file_names
 end
 
+def generate_permission(file_status)
+  file_mode = '%06o' % file_status.mode
+  permission = ''
+  [OWNER_DIGIT, GROUP_DIGIT, OTHER_DIGIT].each do |digit|
+    permission += PERMISSIONS[file_mode[digit]]
+  end
+  convert_permission(permission, file_status)
+end
+
+def convert_permission(permission, file_status)
+  case
+  when file_status.setuid?
+    permission[SET_USER_ID_DIGIT] = permission[SET_USER_ID_DIGIT] == "x" ? "s" : "S"
+  when file_status.setgid?
+    permission[SET_GROUP_ID_DIGIT] = permission[SET_GROUP_ID_DIGIT] == "x" ? "s" : "S"
+  when file_status.sticky?
+    permission[STICKY_BIT_DIGIT] = permission[STICKY_BIT_DIGIT] == "x" ? "t" : "T"
+  end
+  permission
+end
+
 def output_long_format(long_format_file_names, total_block_size)
   puts "total: #{total_block_size}"
+  long_format_file_names.each do |long_format_file_name|
+    long_format_file_name.reject { |key| key == :block_size }.each do |key, value|
+      print value
+    end
+  end
+  puts
 end
 
 def calcurate_column_width(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -42,7 +42,7 @@ def main
   sorted_file_names = options['r'] ? file_names.reverse : file_names
   if options['l']
     long_format_file_names = generate_long_format(sorted_file_names)
-    total_block_size = long_format_file_names.inject(0) { |sum, hash| sum + hash[:block_size] }
+    total_block_size = long_format_file_names.sum { |long_format_file_name| long_format_file_name[:block_size] }
     long_format_widths = create_long_format_widths(long_format_file_names)
     output_long_format(long_format_file_names, total_block_size, long_format_widths)
   else

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -97,7 +97,7 @@ end
 def create_long_format_widths(long_format_file_names)
   long_format_widths = {}
   %i[hard_link owner_name group_name bytesize timestamp].each do |long_format_key|
-    long_format_widths[long_format_key] = long_format_file_names.map { |long_format_file_name| long_format_file_name[long_format_key] }.max.to_s.length
+    long_format_widths[long_format_key] = long_format_file_names.map { |long_format_file_name| long_format_file_name[long_format_key].to_s.length }.max
   end
   long_format_widths[:hard_link] += HARD_LINK_FORWARD_WIDTH
   long_format_widths[:bytesize] += BYTESIZE_FORWARD_WIDTH

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -23,7 +23,7 @@ FILE_TYPES = {
   'fifo' => 'p',
   'link' => 'l',
   'socket' => 's'
-}
+}.freeze
 
 PERMISSIONS = {
   '0' => '---',
@@ -34,7 +34,7 @@ PERMISSIONS = {
   '5' => 'r-x',
   '6' => 'rw-',
   '7' => 'rwx'
-}
+}.freeze
 
 def main
   options = ARGV.getopts('arl')
@@ -65,14 +65,14 @@ def generate_long_format(file_names)
       group_name: Etc.getgrgid(file_status.gid).name,
       bytesize: file_status.size,
       timestamp: generate_timestamp(file_status),
-      file_name: file_name
+      file_name:
     }
   end
   long_format_file_names
 end
 
 def generate_permission(file_status)
-  file_mode = '%06o' % file_status.mode
+  file_mode = format('%06o', file_status.mode)
   permission = ''
   [OWNER_DIGIT, GROUP_DIGIT, OTHER_DIGIT].each do |digit|
     permission += PERMISSIONS[file_mode[digit]]
@@ -81,26 +81,25 @@ def generate_permission(file_status)
 end
 
 def convert_permission(permission, file_status)
-  case
-  when file_status.setuid?
-    permission[SET_USER_ID_DIGIT] = permission[SET_USER_ID_DIGIT] == "x" ? "s" : "S"
-  when file_status.setgid?
-    permission[SET_GROUP_ID_DIGIT] = permission[SET_GROUP_ID_DIGIT] == "x" ? "s" : "S"
-  when file_status.sticky?
-    permission[STICKY_BIT_DIGIT] = permission[STICKY_BIT_DIGIT] == "x" ? "t" : "T"
+  if file_status.setuid?
+    permission[SET_USER_ID_DIGIT] = permission[SET_USER_ID_DIGIT] == 'x' ? 's' : 'S'
+  elsif file_status.setgid?
+    permission[SET_GROUP_ID_DIGIT] = permission[SET_GROUP_ID_DIGIT] == 'x' ? 's' : 'S'
+  elsif file_status.sticky?
+    permission[STICKY_BIT_DIGIT] = permission[STICKY_BIT_DIGIT] == 'x' ? 't' : 'T'
   end
   permission
 end
 
 def generate_timestamp(file_status)
   modify_time = file_status.mtime
-  Time.now.year > modify_time.year ? modify_time.strftime("%_m %_d %_5Y") : modify_time.strftime("%_m %_d %H:%M")
+  Time.now.year > modify_time.year ? modify_time.strftime('%_m %_d %_5Y') : modify_time.strftime('%_m %_d %H:%M')
 end
 
 def create_long_format_widths(long_format_file_names)
   long_format_widths = {}
   %i[hard_link owner_name group_name bytesize timestamp].each do |long_format_key|
-     long_format_widths[long_format_key] = long_format_file_names.map { |long_format_file_name| long_format_file_name[long_format_key]}.max.to_s.length
+    long_format_widths[long_format_key] = long_format_file_names.map { |long_format_file_name| long_format_file_name[long_format_key] }.max.to_s.length
   end
   long_format_widths[:hard_link] += HARD_LINK_FORWARD_WIDTH
   long_format_widths[:bytesize] += BYTESIZE_FORWARD_WIDTH
@@ -111,12 +110,11 @@ def output_long_format(long_format_file_names, total_block_size, long_format_wid
   puts "total: #{total_block_size}"
   long_format_file_names.each do |long_format_file_name|
     long_format_file_name.reject { |key| key == :block_size }.each do |key, value|
-      case
-      when key == :hard_link || key == :bytesize
+      if %i[hard_link bytesize].include?(key)
         print value.to_s.rjust(long_format_widths[key])
-      when key == :owner_name || key == :group_name
+      elsif %i[owner_name group_name].include?(key)
         print value.to_s.ljust(long_format_widths[key]).center(long_format_widths[key] + LONG_FORMAT_SIDE_WIDTH)
-      when key == :timestamp
+      elsif key == :timestamp
         print value.to_s.center(long_format_widths[key] + LONG_FORMAT_SIDE_WIDTH)
       else
         print value

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -107,16 +107,17 @@ end
 def output_long_format_files(files, total_block_size, widths)
   puts "total #{total_block_size}"
   files.each do |file|
-    file.reject { it == :block_size }.each do |key, value|
-      if %i[hard_link bytesize].include?(key)
-        print value.to_s.rjust(widths[key])
-      elsif %i[owner_name group_name].include?(key)
-        print value.ljust(widths[key]).center(widths[key] + LONG_FORMAT_SIDE_WIDTH)
-      elsif key == :timestamp
-        print value.to_s.center(widths[key] + LONG_FORMAT_SIDE_WIDTH)
-      else
-        print value
-      end
+    file.each do |key, value|
+      next if key == :block_size
+
+      print case key
+            when :hard_link, :bytesize
+              value.to_s.rjust(widths[key])
+            when :owner_name, :group_name, :timestamp
+              value.ljust(widths[key]).center(widths[key] + LONG_FORMAT_SIDE_WIDTH)
+            else
+              value
+            end
     end
     puts
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -41,10 +41,10 @@ def main
   file_names = Dir.glob('*', options['a'] ? File::FNM_DOTMATCH : 0)
   sorted_file_names = options['r'] ? file_names.reverse : file_names
   if options['l']
+    total_block_size = sorted_file_names.sum { File::Stat.new(it).blocks }
     long_format_files = generate_long_format_files(sorted_file_names)
-    total_block_size = long_format_files.sum { it[:block_size] }
     long_format_widths = generate_long_format_widths(long_format_files)
-    output_long_format_files(long_format_files, total_block_size, long_format_widths)
+    output_long_format_files(total_block_size, long_format_files, long_format_widths)
   else
     number_of_rows = sorted_file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
     column_width = calcurate_column_width(sorted_file_names)
@@ -56,7 +56,6 @@ def generate_long_format_files(file_names)
   file_names.map do |file_name|
     file_status = File::Stat.new(file_name)
     {
-      block_size: file_status.blocks,
       file_type: FILE_TYPES[file_status.ftype],
       permission: generate_permission(file_status),
       hard_link: file_status.nlink,
@@ -100,12 +99,10 @@ def generate_long_format_widths(files)
   widths
 end
 
-def output_long_format_files(files, total_block_size, widths)
+def output_long_format_files(total_block_size, files, widths)
   puts "total #{total_block_size}"
   files.each do |file|
     file.each do |key, value|
-      next if key == :block_size
-
       print case key
             when :hard_link, :bytesize
               value.to_s.rjust(widths[key])

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -58,7 +58,10 @@ def generate_long_format(file_names)
       permission: generate_permission(file_status),
       hard_link: file_status.nlink,
       owner_name: Etc.getpwuid(file_status.uid).name,
-      group_name: Etc.getgrgid(file_status.gid).name
+      group_name: Etc.getgrgid(file_status.gid).name,
+      bytesize: file_status.size,
+      timestamp: generate_timestamp(file_status),
+      file_name: file_name
     }
   end
   long_format_file_names
@@ -83,6 +86,11 @@ def convert_permission(permission, file_status)
     permission[STICKY_BIT_DIGIT] = permission[STICKY_BIT_DIGIT] == "x" ? "t" : "T"
   end
   permission
+end
+
+def generate_timestamp(file_status)
+  modify_time = file_status.mtime
+  Time.now.year > modify_time.year ? modify_time.strftime("%_m %_d %_5Y") : modify_time.strftime("%_m %_d %H:%M")
 end
 
 def output_long_format(long_format_file_names, total_block_size)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -92,9 +92,8 @@ def generate_timestamp(file_status)
 end
 
 def generate_long_format_widths(files)
-  widths = {}
-  %i[hard_link owner_name group_name bytesize timestamp].each do |key|
-    widths[key] = files.map { it[key].to_s.length }.max
+  widths = %i[hard_link owner_name group_name bytesize timestamp].each_with_object({}) do |key, hash|
+    hash[key] = files.map { it[key].to_s.length }.max
   end
   widths[:hard_link] += HARD_LINK_FORWARD_WIDTH
   widths[:bytesize] += BYTESIZE_FORWARD_WIDTH

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -107,14 +107,17 @@ end
 def output_long_format_files(files, total_block_size, widths)
   puts "total #{total_block_size}"
   files.each do |file|
-    print file[:file_type]
-    print file[:permission]
-    print file[:hard_link].to_s.rjust(widths[:hard_link])
-    print file[:owner_name].ljust(widths[:owner_name]).center(widths[:owner_name] + LONG_FORMAT_SIDE_WIDTH)
-    print file[:group_name].ljust(widths[:group_name]).center(widths[:group_name] + LONG_FORMAT_SIDE_WIDTH)
-    print file[:bytesize].to_s.rjust(widths[:bytesize])
-    print file[:timestamp].to_s.center(widths[:timestamp] + LONG_FORMAT_SIDE_WIDTH)
-    print file[:file_name]
+    file.reject { it == :block_size }.each do |key, value|
+      if %i[hard_link bytesize].include?(key)
+        print value.to_s.rjust(widths[key])
+      elsif %i[owner_name group_name].include?(key)
+        print value.ljust(widths[key]).center(widths[key] + LONG_FORMAT_SIDE_WIDTH)
+      elsif key == :timestamp
+        print value.to_s.center(widths[key] + LONG_FORMAT_SIDE_WIDTH)
+      else
+        print value
+      end
+    end
     puts
   end
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -105,21 +105,18 @@ def create_long_format_widths(long_format_file_names)
 end
 
 def output_long_format(long_format_file_names, total_block_size, long_format_widths)
-  puts "total: #{total_block_size}"
+  puts "total #{total_block_size}"
   long_format_file_names.each do |long_format_file_name|
-    long_format_file_name.reject { |key| key == :block_size }.each do |key, value|
-      if %i[hard_link bytesize].include?(key)
-        print value.to_s.rjust(long_format_widths[key])
-      elsif %i[owner_name group_name].include?(key)
-        print value.to_s.ljust(long_format_widths[key]).center(long_format_widths[key] + LONG_FORMAT_SIDE_WIDTH)
-      elsif key == :timestamp
-        print value.to_s.center(long_format_widths[key] + LONG_FORMAT_SIDE_WIDTH)
-      else
-        print value
-      end
-    end
+    print long_format_file_name[:file_type]
+    print long_format_file_name[:permission]
+    print long_format_file_name[:hard_link].to_s.rjust(long_format_widths[:hard_link])
+    print long_format_file_name[:owner_name].ljust(long_format_widths[:owner_name]).center(long_format_widths[:owner_name] + LONG_FORMAT_SIDE_WIDTH)
+    print long_format_file_name[:group_name].ljust(long_format_widths[:group_name]).center(long_format_widths[:group_name] + LONG_FORMAT_SIDE_WIDTH)
+    print long_format_file_name[:bytesize].to_s.rjust(long_format_widths[:bytesize])
+    print long_format_file_name[:timestamp].to_s.center(long_format_widths[:timestamp] + LONG_FORMAT_SIDE_WIDTH)
+    print long_format_file_name[:file_name]
+    puts
   end
-  puts
 end
 
 def calcurate_column_width(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -42,7 +42,7 @@ def main
   sorted_file_names = options['r'] ? file_names.reverse : file_names
   if options['l']
     long_format_files = generate_long_format_files(sorted_file_names)
-    total_block_size = long_format_files.sum { |long_format_file| long_format_file[:block_size] }
+    total_block_size = long_format_files.sum { it[:block_size] }
     long_format_widths = generate_long_format_widths(long_format_files)
     output_long_format_files(long_format_files, total_block_size, long_format_widths)
   else
@@ -97,7 +97,7 @@ end
 def generate_long_format_widths(files)
   widths = {}
   %i[hard_link owner_name group_name bytesize timestamp].each do |key|
-    widths[key] = files.map { |file| file[key].to_s.length }.max
+    widths[key] = files.map { it[key].to_s.length }.max
   end
   widths[:hard_link] += HARD_LINK_FORWARD_WIDTH
   widths[:bytesize] += BYTESIZE_FORWARD_WIDTH

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -53,10 +53,9 @@ def main
 end
 
 def generate_long_format(file_names)
-  long_format_file_names = []
-  file_names.each do |file_name|
+  file_names.map do |file_name|
     file_status = File::Stat.new(file_name)
-    long_format_file_names << {
+    {
       block_size: file_status.blocks,
       file_type: FILE_TYPES[file_status.ftype],
       permission: generate_permission(file_status),
@@ -68,7 +67,6 @@ def generate_long_format(file_names)
       file_name:
     }
   end
-  long_format_file_names
 end
 
 def generate_permission(file_status)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'etc'
 
 MAX_NUMBER_OF_COLUMNS = 3
 TAB_WIDTH = 8 # ターミナルのデフォルトのタブの文字数
@@ -54,7 +55,10 @@ def generate_long_format(file_names)
     long_format_file_names << {
       block_size: file_status.blocks,
       file_type: FILE_TYPES[file_status.ftype],
-      permission: generate_permission(file_status)
+      permission: generate_permission(file_status),
+      hard_link: file_status.nlink,
+      owner_name: Etc.getpwuid(file_status.uid).name,
+      group_name: Etc.getgrgid(file_status.gid).name
     }
   end
   long_format_file_names

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -11,6 +11,9 @@ OTHER_DIGIT = 5
 SET_USER_ID_DIGIT = 2
 SET_GROUP_ID_DIGIT = 5
 STICKY_BIT_DIGIT = 8
+HARD_LINK_FORWARD_WIDTH = 2
+BYTESIZE_FORWARD_WIDTH = 1
+LONG_FORMAT_SIDE_WIDTH = 2
 
 FILE_TYPES = {
   'file' => '-',
@@ -40,7 +43,8 @@ def main
   if options['l']
     long_format_file_names = generate_long_format(sorted_file_names)
     total_block_size = long_format_file_names.inject(0) { |sum, hash| sum + hash[:block_size] }
-    output_long_format(long_format_file_names, total_block_size)
+    long_format_widths = create_long_format_widths(long_format_file_names)
+    output_long_format(long_format_file_names, total_block_size, long_format_widths)
   else
     number_of_rows = sorted_file_names.length.ceildiv(MAX_NUMBER_OF_COLUMNS)
     column_width = calcurate_column_width(sorted_file_names)
@@ -93,11 +97,30 @@ def generate_timestamp(file_status)
   Time.now.year > modify_time.year ? modify_time.strftime("%_m %_d %_5Y") : modify_time.strftime("%_m %_d %H:%M")
 end
 
-def output_long_format(long_format_file_names, total_block_size)
+def create_long_format_widths(long_format_file_names)
+  long_format_widths = {}
+  %i[hard_link owner_name group_name bytesize timestamp].each do |long_format_key|
+     long_format_widths[long_format_key] = long_format_file_names.map { |long_format_file_name| long_format_file_name[long_format_key]}.max.to_s.length
+  end
+  long_format_widths[:hard_link] += HARD_LINK_FORWARD_WIDTH
+  long_format_widths[:bytesize] += BYTESIZE_FORWARD_WIDTH
+  long_format_widths
+end
+
+def output_long_format(long_format_file_names, total_block_size, long_format_widths)
   puts "total: #{total_block_size}"
   long_format_file_names.each do |long_format_file_name|
     long_format_file_name.reject { |key| key == :block_size }.each do |key, value|
-      print value
+      case
+      when key == :hard_link || key == :bytesize
+        print value.to_s.rjust(long_format_widths[key])
+      when key == :owner_name || key == :group_name
+        print value.to_s.ljust(long_format_widths[key]).center(long_format_widths[key] + LONG_FORMAT_SIDE_WIDTH)
+      when key == :timestamp
+        print value.to_s.center(long_format_widths[key] + LONG_FORMAT_SIDE_WIDTH)
+      else
+        print value
+      end
     end
   end
   puts


### PR DESCRIPTION
## 概要

* [プラクティス lsコマンドを作る4 \| FBC](https://bootcamp.fjord.jp/practices/224)の課題です。
* ls.rbに、-lオプションのふるまいを追加しました。レビューをお願いいたします。
  - 下記のような記載がありましたが、`-r`オプションが実装された状態のコードに`-l`オプションの処理を追加する形にしました。
    - > 前回のプラクティスで実装した-a -rオプションは実装しなくてよいです。（このシリーズ最後のプラクティスで全部合体させます）

## 備考

* 基本的な方針としては以下のように考えて実装しています。
  - 必要な情報を取得してきてリストに詰めていく処理と画面に表示する処理の2段階で実装する。
    - generate_long_format()メソッド: 表示に必要な情報を取得してきてリストに詰めていく処理。
      - データの加工が必要であればここで行う。
    - output_long_format()メソッド: 画面に表示する処理。
      - スペースによる表示の調整などもここで行う。